### PR TITLE
feat: Implement `MemoryUsage` for new types

### DIFF
--- a/crates/loupe-derive/src/lib.rs
+++ b/crates/loupe-derive/src/lib.rs
@@ -63,7 +63,7 @@ fn derive_memory_usage_for_struct(
                     let span = ident.span();
 
                     quote_spanned!(
-                        span => MemoryUsage::size_of_val(&self.#ident, visited) - std::mem::size_of_val(&self.#ident)
+                        span => loupe::MemoryUsage::size_of_val(&self.#ident, visited) - std::mem::size_of_val(&self.#ident)
                     )
                 })
                 .collect(),
@@ -83,7 +83,7 @@ fn derive_memory_usage_for_struct(
                 .map(|(nth, _field)| {
                     let ident = Index::from(nth);
 
-                    quote! { MemoryUsage::size_of_val(&self.#ident, visited) - std::mem::size_of_val(&self.#ident) }
+                    quote! { loupe::MemoryUsage::size_of_val(&self.#ident, visited) - std::mem::size_of_val(&self.#ident) }
                 })
                 .collect(),
         }
@@ -95,10 +95,10 @@ fn derive_memory_usage_for_struct(
     // Implement the `MemoryUsage` trait for `struct_name`.
     (quote! {
         #[allow(dead_code)]
-        impl < #lifetimes_and_generics > MemoryUsage for #struct_name < #lifetimes_and_generics >
+        impl < #lifetimes_and_generics > loupe::MemoryUsage for #struct_name < #lifetimes_and_generics >
         #where_clause
         {
-            fn size_of_val(&self, visited: &mut MemoryUsageTracker) -> usize {
+            fn size_of_val(&self, visited: &mut loupe::MemoryUsageTracker) -> usize {
                 std::mem::size_of_val(self) + #sum
             }
         }
@@ -165,7 +165,7 @@ fn derive_memory_usage_for_enum(
                         let sum = {
                             let sum = join_fold(
                                 identifiers.map(|ident| quote! {
-                                    MemoryUsage::size_of_val(#ident, visited) - std::mem::size_of_val(#ident)
+                                    loupe::MemoryUsage::size_of_val(#ident, visited) - std::mem::size_of_val(#ident)
                                 }),
                                 |x, y| quote! { #x + #y },
                                 quote! { 0 },
@@ -227,7 +227,7 @@ fn derive_memory_usage_for_enum(
                         let sum = {
                             let sum = join_fold(
                                 identifiers.map(|ident| quote! {
-                                    MemoryUsage::size_of_val(#ident, visited) - std::mem::size_of_val(#ident)
+                                    loupe::MemoryUsage::size_of_val(#ident, visited) - std::mem::size_of_val(#ident)
                                 }),
                                 |x, y| quote! { #x + #y },
                                 quote! { 0 },
@@ -253,10 +253,10 @@ fn derive_memory_usage_for_enum(
     // Implement the `MemoryUsage` trait for `enum_name`.
     (quote! {
         #[allow(dead_code)]
-        impl < #lifetimes_and_generics > MemoryUsage for #enum_name < #lifetimes_and_generics >
+        impl < #lifetimes_and_generics > loupe::MemoryUsage for #enum_name < #lifetimes_and_generics >
         #where_clause
         {
-            fn size_of_val(&self, visited: &mut MemoryUsageTracker) -> usize {
+            fn size_of_val(&self, visited: &mut loupe::MemoryUsageTracker) -> usize {
                 std::mem::size_of_val(self) + match self {
                     #match_arms
                 }

--- a/crates/loupe-derive/tests/basic.rs
+++ b/crates/loupe-derive/tests/basic.rs
@@ -1,4 +1,4 @@
-use loupe::{MemoryUsage, MemoryUsageTracker};
+use loupe::MemoryUsage;
 use loupe_derive::MemoryUsage;
 
 use std::collections::BTreeSet;

--- a/crates/loupe/Cargo.toml
+++ b/crates/loupe/Cargo.toml
@@ -5,9 +5,3 @@ description = "Memory profiling tool for Rust"
 repository = "https://github.com/wasmerio/loupe"
 license = "MIT"
 edition = "2018"
-
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.3"
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-libc = { version = "^0.2", default-features = false }

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -587,8 +587,6 @@ mod test_sync_types {
     }
 }
 
-// Mutex types.
-
 impl<T> MemoryUsage for std::marker::PhantomData<T> {
     fn size_of_val(&self, _: &mut dyn MemoryUsageTracker) -> usize {
         0
@@ -604,6 +602,5 @@ impl<T> MemoryUsage for std::marker::PhantomData<T> {
 // * Ref
 // * RefCell
 // * RefMut
-// * RwLock
 // * UnsafeCell
 // * PhantomPinned

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -232,6 +232,12 @@ impl MemoryUsage for &str {
     }
 }
 
+impl MemoryUsage for String {
+    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+        self.as_str().size_of_val(tracker)
+    }
+}
+
 #[cfg(test)]
 mod test_string_types {
     use super::*;
@@ -251,6 +257,24 @@ mod test_string_types {
         assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 3);
 
         let string: &str = "…";
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 3);
+    }
+
+    #[test]
+    fn test_string() {
+        let string: String = "".to_string();
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 0);
+
+        let string: String = "a".to_string();
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 1);
+
+        let string: String = "ab".to_string();
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 2);
+
+        let string: String = "abc".to_string();
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 3);
+
+        let string: String = "…".to_string();
         assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 3);
     }
 }

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -55,7 +55,7 @@ macro_rules! impl_memory_usage_for_primitive {
         }
     };
 
-    ( $( $type:ty ),+ ) => {
+    ( $( $type:ty ),+ $(,)* ) => {
         $( impl_memory_usage_for_primitive!( $type ); )+
     }
 }
@@ -279,7 +279,72 @@ mod test_string_types {
     }
 }
 
-// TODO: tuples
+// Tuple types.
+macro_rules! impl_memory_usage_for_tuple {
+    ( $first_type:ident $(,)* ) => {};
+
+    ( $first_type:ident $( , $types:ident )+ $(,)* ) => {
+        impl< $first_type $( , $types )+ > MemoryUsage for ( $first_type $( , $types )+ )
+        where
+            $first_type: MemoryUsage,
+            $( $types: MemoryUsage ),*
+        {
+            fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+                #[allow(non_snake_case)]
+                let ( $first_type $( , $types )+ ) = self;
+
+                mem::size_of_val(self)
+                    + $first_type.size_of_val(tracker) - mem::size_of_val($first_type)
+                    $( + $types.size_of_val(tracker) - mem::size_of_val($types) )+
+            }
+        }
+
+        impl_memory_usage_for_tuple!( $( $types ),+ );
+    };
+}
+
+impl_memory_usage_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+
+#[cfg(test)]
+mod test_tuple_types {
+    use super::*;
+
+    #[test]
+    fn test_tuple() {
+        let tuple: (i8, i8) = (1, 2);
+        assert_size_of_val_eq!(tuple, 1 /* i8 */ + 1 /* i8 */);
+
+        let tuple: (i8, i16) = (1, 2);
+        assert_size_of_val_eq!(tuple, 1 /* i8 */ + 2 /* i16 */ + 1 /* padding */);
+
+        let tuple: (i8, i16, i32) = (1, 2, 3);
+        assert_size_of_val_eq!(
+            tuple,
+            1 /* i8 */ + 2 /* i16 */ + 4 /* i32 */ + 1 /* padding */
+        );
+
+        let tuple: (i32, i32) = (1, 2);
+        assert_size_of_val_eq!(tuple, 4 /* i32 */ + 4 /* i32 */);
+
+        let tuple: (&str, &str) = ("", "");
+        assert_size_of_val_eq!(
+            tuple,
+            2 * POINTER_BYTE_SIZE + 1 * 0 /* str */ + 2 * POINTER_BYTE_SIZE + 1 * 0 /* str */
+        );
+
+        let tuple: (&str, &str) = ("a", "bc");
+        assert_size_of_val_eq!(
+            tuple,
+            2 * POINTER_BYTE_SIZE + 1 * 1 /* str */ + 2 * POINTER_BYTE_SIZE + 1 * 2 /* str */
+        );
+
+        let tuple: (&str, (i64, i64, i8)) = ("abc", (1, 2, 3));
+        assert_size_of_val_eq!(
+            tuple,
+            2 * POINTER_BYTE_SIZE + 1 * 3 /* str */ + 8 /* i64 */ + 8 /* i64 */ + 1 /* i8 */ + 7 /* padding */
+        );
+    }
+}
 
 /// Standard library types
 

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -191,7 +191,7 @@ mod test_slice_types {
     }
 }
 
-// arrays
+// Array types.
 impl<T: MemoryUsage, const N: usize> MemoryUsage for [T; N] {
     fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
         mem::size_of_val(self)
@@ -199,6 +199,29 @@ impl<T: MemoryUsage, const N: usize> MemoryUsage for [T; N] {
                 .iter()
                 .map(|v| MemoryUsage::size_of_val(v, tracker) - mem::size_of_val(v))
                 .sum::<usize>()
+    }
+}
+
+#[cfg(test)]
+mod test_array_types {
+    use super::*;
+
+    #[test]
+    fn test_array() {
+        let array: [i16; 0] = [0; 0];
+        assert_size_of_val_eq!(array, 2 * 0);
+
+        let array: [i16; 1] = [0; 1];
+        assert_size_of_val_eq!(array, 2 * 1);
+
+        let array: [i16; 2] = [0; 2];
+        assert_size_of_val_eq!(array, 2 * 2);
+
+        let array: [i16; 3] = [0; 3];
+        assert_size_of_val_eq!(array, 2 * 3);
+
+        let array: [[i16; 3]; 5] = [[0; 3]; 5];
+        assert_size_of_val_eq!(array, 2 * 3 * 5);
     }
 }
 
@@ -293,13 +316,6 @@ mod tests {
     fn test_ints() {
         assert_eq!(MemoryUsage::size_of_val(&32, &mut BTreeSet::new()), 4);
         assert_eq!(32.size_of_val(&mut BTreeSet::new()), 4);
-    }
-
-    #[test]
-    fn test_arrays() {
-        let x: [[u8; 7]; 13] = [[0; 7]; 13];
-        assert_eq!(7 * 13, mem::size_of_val(&x));
-        assert_eq!(7 * 13, MemoryUsage::size_of_val(&x, &mut BTreeSet::new()));
     }
 
     #[test]

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -511,7 +511,7 @@ mod test_vec_types {
 }
 
 // Arc types.
-impl<T: MemoryUsage> MemoryUsage for Arc<T> {
+impl<T: MemoryUsage + ?Sized> MemoryUsage for Arc<T> {
     fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
         mem::size_of_val(self) + self.as_ref().size_of_val(tracker)
     }

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -148,7 +148,7 @@ impl<T: MemoryUsage> MemoryUsage for [T] {
         mem::size_of_val(self)
             + self
                 .iter()
-                .map(|v| MemoryUsage::size_of_val(v, tracker) - mem::size_of_val(v))
+                .map(|value| value.size_of_val(tracker) - mem::size_of_val(value))
                 .sum::<usize>()
     }
 }
@@ -197,7 +197,7 @@ impl<T: MemoryUsage, const N: usize> MemoryUsage for [T; N] {
         mem::size_of_val(self)
             + self
                 .iter()
-                .map(|v| MemoryUsage::size_of_val(v, tracker) - mem::size_of_val(v))
+                .map(|value| value.size_of_val(tracker) - mem::size_of_val(value))
                 .sum::<usize>()
     }
 }

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -225,14 +225,35 @@ mod test_array_types {
     }
 }
 
-// strs
-/*
-impl MemoryUsage for str {
-    fn size_of_val(&self, _: &mut dyn MemoryUsageTracker) -> usize {
-        self.as_bytes().size_of()
+// String types.
+impl MemoryUsage for &str {
+    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+        mem::size_of_val(self) + self.as_bytes().size_of_val(tracker)
     }
 }
-*/
+
+#[cfg(test)]
+mod test_string_types {
+    use super::*;
+
+    #[test]
+    fn test_str() {
+        let string: &str = "";
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 0);
+
+        let string: &str = "a";
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 1);
+
+        let string: &str = "ab";
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 2);
+
+        let string: &str = "abc";
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 3);
+
+        let string: &str = "…";
+        assert_size_of_val_eq!(string, 2 * POINTER_BYTE_SIZE + 1 * 3);
+    }
+}
 
 // TODO: tuples
 

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -359,19 +359,9 @@ mod test_tuple_types {
 // Standard library types
 
 // Box types.
-impl<T: MemoryUsage> MemoryUsage for Box<T> {
+impl<T: MemoryUsage + ?Sized> MemoryUsage for Box<T> {
     fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
         mem::size_of_val(self) + self.as_ref().size_of_val(tracker)
-    }
-}
-
-impl<T: MemoryUsage> MemoryUsage for Box<[T]> {
-    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
-        mem::size_of_val(self)
-            + self
-                .iter()
-                .map(|value| value.size_of_val(tracker))
-                .sum::<usize>()
     }
 }
 

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -353,12 +353,41 @@ mod test_tuple_types {
     }
 }
 
-/// Standard library types
+// Standard library types
 
 // TODO: Arc
 
-//impl<T: MemoryUsage> MemoryUsage for Box<T> {
-//}
+// Box types.
+impl<T: MemoryUsage> MemoryUsage for Box<T> {
+    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+        mem::size_of_val(self) + self.as_ref().size_of_val(tracker)
+    }
+}
+
+// TODO: Implement for `Box<[T]>`.
+
+#[cfg(test)]
+mod test_box_types {
+    use super::*;
+
+    #[test]
+    fn test_box() {
+        let b: Box<i8> = Box::new(1);
+        assert_size_of_val_eq!(b, POINTER_BYTE_SIZE + 1);
+
+        let b: Box<i32> = Box::new(1);
+        assert_size_of_val_eq!(b, POINTER_BYTE_SIZE + 4);
+
+        let b: Box<&str> = Box::new("abc");
+        assert_size_of_val_eq!(b, POINTER_BYTE_SIZE + 2 * POINTER_BYTE_SIZE + 1 * 3);
+
+        let b: Box<(i8, i16)> = Box::new((1, 2));
+        assert_size_of_val_eq!(
+            b,
+            POINTER_BYTE_SIZE + 1 /* i8 */ + 2 /* i16 */ + 1 /* padding */
+        );
+    }
+}
 
 // Cell
 

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -44,7 +44,7 @@ impl MemoryUsage for () {
 
 #[cfg(test)]
 macro_rules! assert_size_of_val_eq {
-    ($value:expr, $expected:expr) => {
+    ($value:expr, $expected:expr $(,)*) => {
         assert_eq!(
             MemoryUsage::size_of_val(&$value, &mut BTreeSet::new()),
             $expected
@@ -327,7 +327,7 @@ mod test_tuple_types {
         let tuple: (i8, i16, i32) = (1, 2, 3);
         assert_size_of_val_eq!(
             tuple,
-            1 /* i8 */ + 2 /* i16 */ + 4 /* i32 */ + 1 /* padding */
+            1 /* i8 */ + 2 /* i16 */ + 4 /* i32 */ + 1, /* padding */
         );
 
         let tuple: (i32, i32) = (1, 2);
@@ -336,19 +336,19 @@ mod test_tuple_types {
         let tuple: (&str, &str) = ("", "");
         assert_size_of_val_eq!(
             tuple,
-            2 * POINTER_BYTE_SIZE + 1 * 0 /* str */ + 2 * POINTER_BYTE_SIZE + 1 * 0 /* str */
+            2 * POINTER_BYTE_SIZE + 1 * 0 /* str */ + 2 * POINTER_BYTE_SIZE + 1 * 0, /* str */
         );
 
         let tuple: (&str, &str) = ("a", "bc");
         assert_size_of_val_eq!(
             tuple,
-            2 * POINTER_BYTE_SIZE + 1 * 1 /* str */ + 2 * POINTER_BYTE_SIZE + 1 * 2 /* str */
+            2 * POINTER_BYTE_SIZE + 1 * 1 /* str */ + 2 * POINTER_BYTE_SIZE + 1 * 2, /* str */
         );
 
         let tuple: (&str, (i64, i64, i8)) = ("abc", (1, 2, 3));
         assert_size_of_val_eq!(
             tuple,
-            2 * POINTER_BYTE_SIZE + 1 * 3 /* str */ + 8 /* i64 */ + 8 /* i64 */ + 1 /* i8 */ + 7 /* padding */
+            2 * POINTER_BYTE_SIZE + 1 * 3 /* str */ + 8 /* i64 */ + 8 /* i64 */ + 1 /* i8 */ + 7, /* padding */
         );
     }
 }
@@ -380,7 +380,7 @@ mod test_box_types {
         let b: Box<(i8, i16)> = Box::new((1, 2));
         assert_size_of_val_eq!(
             b,
-            POINTER_BYTE_SIZE + 1 /* i8 */ + 2 /* i16 */ + 1 /* padding */
+            POINTER_BYTE_SIZE + 1 /* i8 */ + 2 /* i16 */ + 1, /* padding */
         );
     }
 }
@@ -420,7 +420,7 @@ mod test_option_types {
         let option: Option<&str> = Some("abc");
         assert_size_of_val_eq!(
             option,
-            1 /* variant */ + 15 /* padding */ + 2 * POINTER_BYTE_SIZE + 1 * 3 /* &str */
+            1 /* variant */ + 15 /* padding */ + 2 * POINTER_BYTE_SIZE + 1 * 3, /* &str */
         );
     }
 }

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -439,6 +439,34 @@ mod test_option_types {
     }
 }
 
+// Result types.
+impl<T: MemoryUsage, E: MemoryUsage> MemoryUsage for Result<T, E> {
+    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
+        mem::size_of_val(self)
+            + match self.as_ref() {
+                Ok(value) => value.size_of_val(tracker),
+                Err(value) => value.size_of_val(tracker),
+            }
+    }
+}
+
+#[cfg(test)]
+mod test_result_types {
+    use super::*;
+
+    #[test]
+    fn test_result() {
+        let result: Result<i8, i16> = Err(2);
+        assert_size_of_val_eq!(result, 1 /* variant */ + 3 /* padding */ + 2 /* i16 */);
+
+        let result: Result<i8, i16> = Ok(1);
+        assert_size_of_val_eq!(result, 1 /* variant */ + 3 /* padding */ + 1 /* i8 */);
+
+        let result: Result<i32, ()> = Ok(1);
+        assert_size_of_val_eq!(result, 1 /* variant */ + 7 /* padding */ + 4 /* i32 */);
+    }
+}
+
 // TODO: Rc
 
 // TODO: Ref, RefCell, RefMut

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -355,16 +355,12 @@ mod test_tuple_types {
 
 // Standard library types
 
-// TODO: Arc
-
 // Box types.
 impl<T: MemoryUsage> MemoryUsage for Box<T> {
     fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
         mem::size_of_val(self) + self.as_ref().size_of_val(tracker)
     }
 }
-
-// TODO: Implement for `Box<[T]>`.
 
 #[cfg(test)]
 mod test_box_types {
@@ -388,16 +384,6 @@ mod test_box_types {
         );
     }
 }
-
-// Cell
-
-// Is a Pin always dereferenceable?
-//impl<T: MemoryUsage> MemoryUsage for Pin<T> {
-//}
-
-// TODO: Mutex
-
-// TODO: NonNull might be possible when '*const T' is MemoryUsage.
 
 // Option types.
 impl<T: MemoryUsage> MemoryUsage for Option<T> {
@@ -467,17 +453,6 @@ mod test_result_types {
     }
 }
 
-// TODO: Rc
-
-// TODO: Ref, RefCell, RefMut
-
-//impl<T: MemoryUsage, E: MemoryUsage> MemoryUsage for Result<T, E> {
-//}
-
-// TODO: RwLock
-
-// TODO: UnsafeCell
-
 // Vector types.
 impl<T: MemoryUsage> MemoryUsage for Vec<T> {
     fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
@@ -514,7 +489,21 @@ impl<T> MemoryUsage for std::marker::PhantomData<T> {
     }
 }
 
-// TODO: PhantomPinned?
+// TODO:
+//
+// * Box<[T]>
+// * Cell
+// * Arc
+// * Pin (is a Pin always referenceable?)
+// * Mutex
+// * NonNull (might be possible when '*const T' is MemoryUsage)
+// * Rc
+// * Ref
+// * RefCell
+// * RefMut
+// * RwLock
+// * UnsafeCell
+// * PhantomPinned
 
 #[cfg(test)]
 mod tests {

--- a/crates/loupe/src/memory_usage.rs
+++ b/crates/loupe/src/memory_usage.rs
@@ -35,6 +35,13 @@ pub trait MemoryUsage {
     fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize;
 }
 
+// Empty type.
+impl MemoryUsage for () {
+    fn size_of_val(&self, _: &mut dyn MemoryUsageTracker) -> usize {
+        0
+    }
+}
+
 #[cfg(test)]
 macro_rules! assert_size_of_val_eq {
     ($value:expr, $expected:expr) => {


### PR DESCRIPTION
This PR implements `MemoryUsage` on new types. For the moment:

* Array `[T; N]`,
* `&str`,
* `String`
* Tuples `(T0, T1, …, T11)`,
* `()`,
* `Box<T>`,
* `Box<[T]>`,
* `Option<T>`,
* `Result<T, E>`,
* `Vec<T>`,
* `Arc<T>`,
* `Mutex<T>`,
* `RwLock<T>`,
* `HashMap<K, V>`.

Each commit is contains a new type + its tests. The PR can be reviewed commit by commit.