### PR TITLE
feat: Add the `size_of_val` helper

### DIFF
--- a/crates/loupe/src/lib.rs
+++ b/crates/loupe/src/lib.rs
@@ -1,3 +1,18 @@
 mod memory_usage;
 
 pub use memory_usage::{MemoryUsage, MemoryUsageTracker, POINTER_BYTE_SIZE};
+use std::collections::BTreeSet;
+
+pub fn size_of_val<T: MemoryUsage>(value: &T) -> usize {
+    <T as MemoryUsage>::size_of_val(value, &mut BTreeSet::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_size_of_val_helper() {
+        assert_eq!(size_of_val(&"abc"), 2 * POINTER_BYTE_SIZE + 1 * 3);
+    }
+}


### PR DESCRIPTION
This patch adds the `loupe::size_of_val(T)` helper. It calls `MemoryUsage` manually with a `BTreeSet` for the memory tracker.