### PR TITLE
feat: Re-export `loupe_derive` from `loupe`

### DIFF
--- a/crates/loupe-derive/Cargo.toml
+++ b/crates/loupe-derive/Cargo.toml
@@ -12,5 +12,6 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
-loupe = { path = "../loupe", version = "0.1.0" }
 
+[dev-dependencies]
+loupe = { path = "../loupe" }

--- a/crates/loupe-derive/tests/basic.rs
+++ b/crates/loupe-derive/tests/basic.rs
@@ -1,5 +1,4 @@
 use loupe::{MemoryUsage, POINTER_BYTE_SIZE};
-use loupe_derive::MemoryUsage;
 
 use std::collections::BTreeSet;
 

--- a/crates/loupe/Cargo.toml
+++ b/crates/loupe/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
+loupe-derive = { path = "../loupe-derive", optional = true }
 indexmap = { version = "1.6", optional = true }
 
 [features]
+default = ["derive"]
+derive = ["loupe-derive"]
 enable-indexmap = ["indexmap"]

--- a/crates/loupe/src/lib.rs
+++ b/crates/loupe/src/lib.rs
@@ -1,6 +1,9 @@
 mod memory_usage;
 
+#[cfg(feature = "derive")]
+pub use loupe_derive::*;
 pub use memory_usage::*;
+
 use std::collections::BTreeSet;
 
 pub fn size_of_val<T: MemoryUsage>(value: &T) -> usize {


### PR DESCRIPTION
As suggested by @MarkMcCaskey in https://github.com/wasmerio/wasmer/pull/2201#discussion_r597720954.