### PR TITLE
fix(loupe-derive) Handle struct/enum with inlined generics.

### DIFF
--- a/crates/loupe-derive/src/lib.rs
+++ b/crates/loupe-derive/src/lib.rs
@@ -77,8 +77,7 @@ fn derive_memory_usage_for_struct(
     data: &DataStruct,
     generics: &Generics,
 ) -> TokenStream {
-    let lifetimes_and_generics = &generics.params;
-    let where_clause = &generics.where_clause;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let sum = join_fold(
         // Check all fields of the `struct`.
@@ -134,7 +133,7 @@ fn derive_memory_usage_for_struct(
     // Implement the `MemoryUsage` trait for `struct_name`.
     (quote! {
         #[allow(dead_code)]
-        impl < #lifetimes_and_generics > loupe::MemoryUsage for #struct_name < #lifetimes_and_generics >
+        impl #impl_generics loupe::MemoryUsage for #struct_name #ty_generics
         #where_clause
         {
             fn size_of_val(&self, visited: &mut loupe::MemoryUsageTracker) -> usize {
@@ -150,8 +149,7 @@ fn derive_memory_usage_for_enum(
     data: &DataEnum,
     generics: &Generics,
 ) -> TokenStream {
-    let lifetimes_and_generics = &generics.params;
-    let where_clause = &generics.where_clause;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let match_arms = join_fold(
         data.variants
@@ -296,7 +294,7 @@ fn derive_memory_usage_for_enum(
     // Implement the `MemoryUsage` trait for `enum_name`.
     (quote! {
         #[allow(dead_code)]
-        impl < #lifetimes_and_generics > loupe::MemoryUsage for #enum_name < #lifetimes_and_generics >
+        impl #impl_generics loupe::MemoryUsage for #enum_name #ty_generics
         #where_clause
         {
             fn size_of_val(&self, visited: &mut loupe::MemoryUsageTracker) -> usize {

--- a/crates/loupe/tests/derive.rs
+++ b/crates/loupe/tests/derive.rs
@@ -58,12 +58,23 @@ fn test_tuple() {
 }
 
 #[test]
-fn test_struct_generic() {
+fn test_struct_with_generic() {
     #[derive(MemoryUsage)]
     struct Generic<T>
     where
         T: MemoryUsage,
     {
+        x: T,
+        y: T,
+    }
+
+    assert_size_of_val_eq!(16, Generic { x: 1i64, y: 2i64 });
+}
+
+#[test]
+fn test_struct_with_inlined_generic() {
+    #[derive(MemoryUsage)]
+    struct Generic<T: MemoryUsage> {
         x: T,
         y: T,
     }
@@ -126,6 +137,33 @@ fn test_enum() {
         48,
         Things::Points(vec![Point { x: 1, y: 2 }, Point { x: 3, y: 4 }])
     );
+}
+
+#[test]
+fn test_enum_with_generic() {
+    #[derive(MemoryUsage)]
+    enum Generic<T>
+    where
+        T: MemoryUsage,
+    {
+        A(T),
+        B(T),
+    }
+
+    assert_size_of_val_eq!(16, Generic::<i64>::A(1));
+    assert_size_of_val_eq!(16, Generic::<i64>::B(2));
+}
+
+#[test]
+fn test_enum_with_inlined_generic() {
+    #[derive(MemoryUsage)]
+    enum Generic<T: MemoryUsage> {
+        A(T),
+        B(T),
+    }
+
+    assert_size_of_val_eq!(16, Generic::<i64>::A(1));
+    assert_size_of_val_eq!(16, Generic::<i64>::B(2));
 }
 
 #[test]


### PR DESCRIPTION
```rs
struct S<T: U> {}
```

was incorrectly handled, as the generated code looked like:

```rs
impl<T: U> MemoryUsage for S<T: U> {}
```

rather than:

```rs
impl<T: U> MemoryUsage for S<T> {}
```

This patch fixes that.