### PR TITLE
fix: Use const generics only on nightly or 1.51

### DIFF
--- a/crates/loupe/src/memory_usage/primitive.rs
+++ b/crates/loupe/src/memory_usage/primitive.rs
@@ -56,7 +56,7 @@ mod test_numeric_types {
     );
 }
 
-#[rustversion::nightly]
+#[rustversion::any(stable(1.51), since(2021-02-01))]
 impl<T, const N: usize> MemoryUsage for [T; N]
 where
     T: MemoryUsage,
@@ -70,7 +70,7 @@ where
     }
 }
 
-#[rustversion::nightly]
+#[rustversion::any(stable(1.51), since(2021-02-01))]
 #[cfg(test)]
 mod test_array_types {
     use super::*;

--- a/crates/loupe/src/memory_usage/slice.rs
+++ b/crates/loupe/src/memory_usage/slice.rs
@@ -34,7 +34,7 @@ where
 mod test_slice_types {
     use super::*;
 
-    #[rustversion::nightly]
+    #[rustversion::any(stable(1.51), since(2021-02-01))]
     #[test]
     fn test_slice() {
         assert_size_of_val_eq!([1i16], 2 * 1);


### PR DESCRIPTION
For nightly, we need to be ensure that it's a “recent” nightly version
that contains the const generics MVP.