### PR TITLE
fix: Size of a pointer is always `POINTER_BYTE_SIZE`.

### DIFF
--- a/crates/loupe/src/memory_usage/cell.rs
+++ b/crates/loupe/src/memory_usage/cell.rs
@@ -6,11 +6,12 @@ use std::mem;
 
 impl<T> MemoryUsage for UnsafeCell<T> {
     fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
-        if tracker.track(self.get() as *const ()) {
-            POINTER_BYTE_SIZE
-        } else {
-            0
-        }
+        mem::size_of_val(self)
+            + if tracker.track(self.get() as *const ()) {
+                POINTER_BYTE_SIZE
+            } else {
+                0
+            }
     }
 }
 
@@ -38,7 +39,7 @@ mod test_cell_types {
     #[test]
     fn test_unsafecell() {
         let cell = UnsafeCell::<i8>::new(1);
-        assert_size_of_val_eq!(cell, POINTER_BYTE_SIZE);
+        assert_size_of_val_eq!(cell, mem::size_of_val(&cell) + POINTER_BYTE_SIZE);
     }
 
     #[test]

--- a/crates/loupe/src/memory_usage/ptr.rs
+++ b/crates/loupe/src/memory_usage/ptr.rs
@@ -5,62 +5,39 @@ use std::mem;
 use std::ptr::NonNull;
 
 impl<T> MemoryUsage for *const T {
-    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
-        if tracker.track(*self as *const ()) {
-            POINTER_BYTE_SIZE
-        } else {
-            0
-        }
+    fn size_of_val(&self, _tracker: &mut dyn MemoryUsageTracker) -> usize {
+        POINTER_BYTE_SIZE
     }
 }
 
 impl<T> MemoryUsage for *mut T {
-    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
-        if tracker.track(*self as *const _ as *const ()) {
-            POINTER_BYTE_SIZE
-        } else {
-            0
-        }
+    fn size_of_val(&self, _tracker: &mut dyn MemoryUsageTracker) -> usize {
+        POINTER_BYTE_SIZE
     }
 }
 
 impl<T> MemoryUsage for NonNull<T> {
-    fn size_of_val(&self, tracker: &mut dyn MemoryUsageTracker) -> usize {
-        if tracker.track(self.as_ptr() as *const _ as *const ()) {
-            POINTER_BYTE_SIZE
-        } else {
-            0
-        }
+    fn size_of_val(&self, _tracker: &mut dyn MemoryUsageTracker) -> usize {
+        POINTER_BYTE_SIZE
     }
 }
 
 #[cfg(test)]
 mod test_pointer_types {
     use super::*;
-    use std::collections::BTreeSet;
 
     #[test]
     fn test_pointer() {
-        let mut tracker = BTreeSet::new();
-
         let x = 1i8;
         let ptr = &x as *const _;
-        assert_size_of_val_eq!(ptr, POINTER_BYTE_SIZE, &mut tracker);
-
-        let ptr = &x as *const _;
-        assert_size_of_val_eq!(ptr, 0, &mut tracker);
+        assert_size_of_val_eq!(ptr, POINTER_BYTE_SIZE);
     }
 
     #[test]
     fn test_mutable_pointer() {
-        let mut tracker = BTreeSet::new();
-
         let mut x = 1i8;
         let ptr = &mut x as *mut _;
-        assert_size_of_val_eq!(ptr, POINTER_BYTE_SIZE, &mut tracker);
-
-        let ptr = &mut x as *mut _;
-        assert_size_of_val_eq!(ptr, 0, &mut tracker);
+        assert_size_of_val_eq!(ptr, POINTER_BYTE_SIZE);
     }
 
     #[test]

--- a/crates/loupe/tests/derive.rs
+++ b/crates/loupe/tests/derive.rs
@@ -55,6 +55,12 @@ fn test_tuple() {
     struct Tuple(i32, i32);
 
     assert_size_of_val_eq!(8, Tuple(1, 2));
+
+    #[derive(MemoryUsage)]
+    #[repr(transparent)]
+    struct Ptr(*const usize);
+
+    assert_size_of_val_eq!(8, Ptr(&1));
 }
 
 #[test]


### PR DESCRIPTION
This patch does 2 things:

1. The size of a pointer must always be `POINTER_BYTE_SIZE`. The tracker
  must not come up in this level, it must be used in upper types.
2. The size of an `UnsafeCell` is the size of itself, in addition to the
  size of its content (viewed as a pointer) if not visited already.

It addresses https://github.com/CosmWasm/cosmwasm/issues/959.